### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Please refer to the table below.
 | `&&&`    |                    | :heavy_check_mark:     |                         |
 | `<-`     |                    | :heavy_check_mark:     |                         |
 | `\\`     |                    | :heavy_check_mark:     |                         |
-| `|`      |                    |                        | :heavy_check_mark:      |
-| `||`     |                    | :heavy_check_mark:     |                         |
-| `|||`    |                    | :heavy_check_mark:     |                         |
+| `\|`     |                    |                        | :heavy_check_mark:      |
+| `\|\|`   |                    | :heavy_check_mark:     |                         |
+| `\|\|\|` |                    | :heavy_check_mark:     |                         |
 | `=`      |                    |                        | :heavy_check_mark:      |
 | `=~`     |                    | :heavy_check_mark:     |                         |
 | `==`     |                    | :heavy_check_mark:     |                         |
@@ -103,8 +103,8 @@ Please refer to the table below.
 | `<>`     |                    |                        | :heavy_check_mark:      |
 | `<=`     |                    | :heavy_check_mark:     |                         |
 | `>=`     |                    | :heavy_check_mark:     |                         |
-| `|>`     |                    | :heavy_check_mark:     |                         |
-| `<|>`    |                    | :heavy_check_mark:     |                         |
+| `\|>`    |                    | :heavy_check_mark:     |                         |
+| `<\|>`   |                    | :heavy_check_mark:     |                         |
 | `<~>`    |                    | :heavy_check_mark:     |                         |
 | `~>`     |                    | :heavy_check_mark:     |                         |
 | `~>>`    |                    | :heavy_check_mark:     |                         |


### PR DESCRIPTION
It seems that in GitHub Flavoured Markdown, pipe characters used in a table need to be escaped, even if they are inside a code block.

This tiny change performs this escaping to ensure that the table in the README is rendered properly.